### PR TITLE
Fixed AUTHFILE Storage

### DIFF
--- a/clion.js
+++ b/clion.js
@@ -2,7 +2,7 @@
 const VERSION = "0.1.0",
 	DESCRIPTION = "A command line interface for TJHSST Ion",
 	WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
-	AUTHFILE = require('os').tmpdir() + "/clion-auth";
+	AUTHFILE = require('path').join(__dirname, 'clion-auth');
 
 const fs = require('fs'),
 	program = require('gitlike-cli'),


### PR DESCRIPTION
The `AUTHFILE` constant now points to the directory in which npm installs the module. This solution should allow Clion to work on both UNIX and Windows while making the AUTHFILE persistent between reboots.